### PR TITLE
fix: svdw params prefer z = ±(1+n) to ±(i+n)

### DIFF
--- a/mapping/svdw.go
+++ b/mapping/svdw.go
@@ -26,7 +26,7 @@ func NewSVDW(e C.EllCurve) MapToCurve {
 func (m *svdw) findZ() {
 	F := m.E.F
 	_Half := F.Inv(F.Neg(F.Elt(2))) // -1/2
-	ctr := F.Generator()
+	ctr := F.One()
 	for {
 		for _, z := range []GF.Elt{ctr, F.Neg(ctr)} {
 			g2 := m.E.EvalRHS(F.Mul(z, _Half)) // g(-z/2)


### PR DESCRIPTION
In accordance with version 14 of the standard:
https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#appendix-H.1